### PR TITLE
Framework version compatibility fixes

### DIFF
--- a/App/App.csproj
+++ b/App/App.csproj
@@ -17,7 +17,6 @@
       <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.6" />
       <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.6.0" />
       <PackageReference Include="NJsonSchema" Version="11.3.2" />
-      <PackageReference Include="NJsonSchema.CodeGeneration" Version="11.3.2" />
       <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
       <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />

--- a/App/App.csproj
+++ b/App/App.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net8.0-windows</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
@@ -17,6 +17,7 @@
       <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.6" />
       <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.6.0" />
       <PackageReference Include="NJsonSchema" Version="11.3.2" />
+      <PackageReference Include="NJsonSchema.CodeGeneration" Version="11.3.2" />
       <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
       <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
       <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />

--- a/Tests/HidHideApiTests.cs
+++ b/Tests/HidHideApiTests.cs
@@ -2,7 +2,7 @@ using Nefarius.Drivers.HidHide;
 
 namespace Tests;
 
-internal class Tests
+internal partial class Tests
 {
     [SetUp]
     public void Setup()

--- a/Tests/OnlineServiceTests.cs
+++ b/Tests/OnlineServiceTests.cs
@@ -18,7 +18,41 @@ internal partial class Tests
         HidHideSetupProvider provider = sp.GetRequiredService<HidHideSetupProvider>();
 
         UpdateRelease release = await provider.GetLatestReleaseAsync();
+
+        Assert.That(release, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task TestGetLatestVersionAsync()
+    {
+        ServiceCollection sc = new();
+        sc.AddHidHide();
+
+        ServiceProvider sp = sc.BuildServiceProvider();
+
+        HidHideSetupProvider provider = sp.GetRequiredService<HidHideSetupProvider>();
+
+        Version version = await provider.GetLatestVersionAsync();
+
+        Assert.That(version, Is.EqualTo(Version.Parse("1.5.230.0")));
+    }
+
+    [Test]
+    public async Task TestDownloadLatestReleaseAsync()
+    {
+        ServiceCollection sc = new();
+        sc.AddHidHide();
+
+        ServiceProvider sp = sc.BuildServiceProvider();
+
+        HidHideSetupProvider provider = sp.GetRequiredService<HidHideSetupProvider>();
+
+        HttpResponseMessage response = await provider.DownloadLatestReleaseAsync();
+
+        Assert.That(response.IsSuccessStatusCode, Is.True);
+
+        byte[] body = await response.Content.ReadAsByteArrayAsync();
         
-        Assert.Pass();
+        Assert.That(body, Is.Not.Empty);
     }
 }

--- a/Tests/OnlineServiceTests.cs
+++ b/Tests/OnlineServiceTests.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+using Nefarius.Drivers.HidHide;
+using Nefarius.Vicius.Abstractions.Models;
+
+namespace Tests;
+
+internal partial class Tests
+{
+    [Test]
+    public async Task TestGetLatestReleaseAsync()
+    {
+        ServiceCollection sc = new();
+        sc.AddHidHide();
+
+        ServiceProvider sp = sc.BuildServiceProvider();
+
+        HidHideSetupProvider provider = sp.GetRequiredService<HidHideSetupProvider>();
+
+        UpdateRelease release = await provider.GetLatestReleaseAsync();
+        
+        Assert.Pass();
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -8,10 +8,12 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.6" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="NJsonSchema" Version="11.3.2" />
         <PackageReference Include="NUnit" Version="4.3.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.9.1">
+        <PackageReference Include="NUnit.Analyzers" Version="4.9.1">            
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Nefarius.Drivers.HidHide.csproj
+++ b/src/Nefarius.Drivers.HidHide.csproj
@@ -27,7 +27,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Nefarius.Utilities.DeviceManagement" Version="5.1.0" />
-        <PackageReference Include="Nefarius.Vicius.Abstractions" Version="1.3.1" />
+        <PackageReference Include="Nefarius.Vicius.Abstractions" Version="1.4.0" />
         <PackageReference Include="System.Memory" Version="4.6.3" />
         <PackageReference Include="System.Net.Http.Json" Version="9.0.6" />
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />

--- a/src/Nefarius.Drivers.HidHide.csproj
+++ b/src/Nefarius.Drivers.HidHide.csproj
@@ -3,12 +3,13 @@
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;net8.0-windows;net9.0-windows</TargetFrameworks>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <LangVersion>latest</LangVersion>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Version>1.0.0</Version>
         <RepositoryUrl>https://github.com/nefarius/Nefarius.Drivers.HidHide</RepositoryUrl>
         <PackageProjectUrl>https://github.com/nefarius/Nefarius.Drivers.HidHide</PackageProjectUrl>
-        <Description>Managed API for configuring HidHide.</Description>
+        <Description>Managed API for configuring HidHide.</Description>        
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
- Fixed an issue with [Nefarius.Vicius.Abstractions](https://github.com/nefarius/Nefarius.Vicius.Abstractions) only supporting `netstandard2.0` and breaking NJsonSchema support.
- Added more unit tests for Web API calls.