### PR TITLE
Rework volume path mapping for robustness

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
         with:
@@ -21,3 +21,6 @@ jobs:
 
       - name: Build
         run: dotnet build -c Release
+
+      - name: Test
+        run: dotnet test -c Release --no-build

--- a/Tests/HidHideApiTests.cs
+++ b/Tests/HidHideApiTests.cs
@@ -22,6 +22,7 @@ internal partial class Tests
     }
 
     [Test]
+    [Explicit("Requires HidHide driver to be installed")]
     public void TestIsActive()
     {
         _hhControl.IsActive = true;
@@ -34,6 +35,7 @@ internal partial class Tests
     }
 
     [Test]
+    [Explicit("Requires HidHide driver to be installed")]
     public void TestIsAppListInverted()
     {
         _hhControl.IsAppListInverted = true;
@@ -46,6 +48,7 @@ internal partial class Tests
     }
 
     [Test]
+    [Explicit("Requires HidHide driver to be installed")]
     public void TestAppListValid()
     {
         _hhControl.ClearApplicationsList();

--- a/Tests/VolumeHelperTests.cs
+++ b/Tests/VolumeHelperTests.cs
@@ -288,20 +288,6 @@ internal sealed class VolumeHelperTests
     }
 
     [Test]
-    public void VolumeHelper_PropagatesWin32Exception_EvenWhenThrowOnErrorIsFalse()
-    {
-        VolumeHelper helper = new(null, new ThrowingProvider());
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(() => helper.PathToDosDevicePath(@"C:\nonexistent\App.exe", throwOnError: false),
-                Throws.InstanceOf<System.ComponentModel.Win32Exception>());
-            Assert.That(() => helper.DosDevicePathToPath(@"\Device\HarddiskVolume1\App.exe", throwOnError: false),
-                Throws.InstanceOf<System.ComponentModel.Win32Exception>());
-        });
-    }
-
-    [Test]
     public void DosDevicePathToPath_PrefersLongestMountPoint_EvenWhenRegisteredInReversedOrder()
     {
         // Verify the tie-break also works when the shorter mount point appears second in the list.
@@ -354,13 +340,6 @@ internal sealed class VolumeHelperTests
         }
     }
 
-    private sealed class ThrowingProvider : IVolumeMappingProvider
-    {
-        public IReadOnlyList<VolumeMapping> GetVolumeMappings()
-        {
-            throw new System.ComponentModel.Win32Exception(2);
-        }
-    }
 
     private sealed class TempFile : IDisposable
     {

--- a/Tests/VolumeHelperTests.cs
+++ b/Tests/VolumeHelperTests.cs
@@ -1,0 +1,338 @@
+using Nefarius.Drivers.HidHide.Util;
+
+namespace Tests;
+
+internal sealed class VolumeHelperTests
+{
+    [Test]
+    public void PathToDosDevicePath_UsesLongestMatchingMountPoint()
+    {
+        using TempFile tempFile = TempFile.Create("Application.exe", "nested");
+        string root = Path.GetPathRoot(tempFile.Path)!;
+        string mountPoint = Path.GetDirectoryName(Path.GetDirectoryName(tempFile.Path)!)! + Path.DirectorySeparatorChar;
+
+        VolumeHelper helper = CreateHelper(
+            new VolumeMapping(root, @"\\?\Volume{root}\", @"\Device\HarddiskVolume1"),
+            new VolumeMapping(mountPoint, @"\\?\Volume{mount}\", @"\Device\HarddiskVolume2"));
+
+        string? result = helper.PathToDosDevicePath(tempFile.Path);
+
+        Assert.That(result, Is.EqualTo(@"\Device\HarddiskVolume2\nested\Application.exe"));
+    }
+
+    [Test]
+    public void PathToDosDevicePath_IgnoresMalformedMountPoint()
+    {
+        using TempFile tempFile = TempFile.Create("Application.exe");
+        string root = Path.GetPathRoot(tempFile.Path)!;
+
+        // The embedded NUL makes Path.GetFullPath throw ArgumentException on every target framework,
+        // exercising the "skipping unusable mount point" branch instead of an ordinary prefix mismatch.
+        VolumeHelper helper = CreateHelper(
+            new VolumeMapping("C:\\Bro\0ken\\", @"\\?\Volume{broken}\", @"\Device\HarddiskVolume9"),
+            new VolumeMapping(root, @"\\?\Volume{root}\", @"\Device\HarddiskVolume1"));
+
+        string? result = helper.PathToDosDevicePath(tempFile.Path);
+
+        Assert.That(result, Is.EqualTo(@"\Device\HarddiskVolume1\" + Path.GetRelativePath(root, tempFile.Path)));
+    }
+
+    [Test]
+    public void PathToDosDevicePath_SkipsMappingsWithoutMountPoint()
+    {
+        using TempFile tempFile = TempFile.Create("Application.exe");
+        string root = Path.GetPathRoot(tempFile.Path)!;
+
+        VolumeHelper helper = CreateHelper(
+            new VolumeMapping(string.Empty, @"\\?\Volume{none}\", @"\Device\HarddiskVolume9"),
+            new VolumeMapping(root, @"\\?\Volume{root}\", @"\Device\HarddiskVolume1"));
+
+        string? result = helper.PathToDosDevicePath(tempFile.Path);
+
+        Assert.That(result, Is.EqualTo(@"\Device\HarddiskVolume1\" + Path.GetRelativePath(root, tempFile.Path)));
+    }
+
+    [Test]
+    public void PathToDosDevicePath_CanonicalizesParentDirectorySegments()
+    {
+        using TempFile tempFile = TempFile.Create("Application.exe", "nested");
+        string root = Path.GetPathRoot(tempFile.Path)!;
+        string directory = Path.GetDirectoryName(tempFile.Path)!;
+        string dottedPath = Path.Combine(directory, "..", "nested", "Application.exe");
+
+        VolumeHelper helper = CreateHelper(
+            new VolumeMapping(root, @"\\?\Volume{root}\", @"\Device\HarddiskVolume1"));
+
+        string? result = helper.PathToDosDevicePath(dottedPath);
+
+        Assert.That(result, Is.EqualTo(@"\Device\HarddiskVolume1\" + Path.GetRelativePath(root, tempFile.Path)));
+    }
+
+    [Test]
+    public void PathToDosDevicePath_CanonicalizesForwardSlashes()
+    {
+        using TempFile tempFile = TempFile.Create("Application.exe", "nested");
+        string root = Path.GetPathRoot(tempFile.Path)!;
+        string forwardSlashPath = tempFile.Path.Replace('\\', '/');
+
+        VolumeHelper helper = CreateHelper(
+            new VolumeMapping(root, @"\\?\Volume{root}\", @"\Device\HarddiskVolume1"));
+
+        string? result = helper.PathToDosDevicePath(forwardSlashPath);
+
+        Assert.That(result, Is.EqualTo(@"\Device\HarddiskVolume1\" + Path.GetRelativePath(root, tempFile.Path)));
+    }
+
+    [Test]
+    public void PathToDosDevicePath_ReturnsNull_WhenNoMappingMatchesAndThrowOnErrorIsFalse()
+    {
+        using TempFile tempFile = TempFile.Create("Application.exe");
+        string root = Path.GetPathRoot(tempFile.Path)!;
+        string nonMatchingMountPoint =
+            Path.Combine(root, "VolumeHelperTestsNoSuchMount") + Path.DirectorySeparatorChar;
+
+        VolumeHelper helper = CreateHelper(
+            new VolumeMapping(nonMatchingMountPoint, @"\\?\Volume{other}\", @"\Device\HarddiskVolume9"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(helper.PathToDosDevicePath(tempFile.Path, throwOnError: false), Is.Null);
+            Assert.That(() => helper.PathToDosDevicePath(tempFile.Path), Throws.InstanceOf<IOException>());
+        });
+    }
+
+    [Test]
+    public void DosDevicePathToPath_UsesFirstMappingOnEqualDevicePaths()
+    {
+        string root = Path.GetPathRoot(TestContext.CurrentContext.WorkDirectory)!;
+        VolumeHelper helper = CreateHelper(
+            new VolumeMapping(root, @"\\?\Volume{root}\", @"\Device\HarddiskVolume1"),
+            new VolumeMapping(root.TrimEnd(Path.DirectorySeparatorChar) + @"\Mount\", @"\\?\Volume{mount}\", @"\Device\HarddiskVolume1"));
+
+        string? result = helper.DosDevicePathToPath(@"\Device\HarddiskVolume1\Apps\DSX.exe");
+
+        Assert.That(result, Is.EqualTo(Path.Combine(root, "Apps", "DSX.exe")));
+    }
+
+    [Test]
+    public void DosDevicePathToPath_MatchesDevicePathCaseInsensitively()
+    {
+        string root = Path.GetPathRoot(TestContext.CurrentContext.WorkDirectory)!;
+        VolumeHelper helper = CreateHelper(
+            new VolumeMapping(root, @"\\?\Volume{root}\", @"\Device\HarddiskVolume1"));
+
+        string? result = helper.DosDevicePathToPath(@"\device\harddiskvolume1\Apps\DSX.exe");
+
+        Assert.That(result, Is.EqualTo(Path.Combine(root, "Apps", "DSX.exe")));
+    }
+
+    [Test]
+    public void DosDevicePathToPath_SupportsNonHarddiskVolumeDevices()
+    {
+        string root = Path.GetPathRoot(TestContext.CurrentContext.WorkDirectory)!;
+        VolumeHelper helper = CreateHelper(
+            new VolumeMapping(root, @"\\?\Volume{crypt}\", @"\Device\VeraCryptVolumeG"));
+
+        string? result = helper.DosDevicePathToPath(@"\Device\VeraCryptVolumeG\Apps\Game.exe");
+
+        Assert.That(result, Is.EqualTo(Path.Combine(root, "Apps", "Game.exe")));
+    }
+
+    [Test]
+    public void DosDevicePathToPath_DoesNotTreatLongerVolumeNumberAsPrefixMatch()
+    {
+        string root = Path.GetPathRoot(TestContext.CurrentContext.WorkDirectory)!;
+        string mountPoint = root.TrimEnd(Path.DirectorySeparatorChar) + @"\Mount\";
+        VolumeHelper helper = CreateHelper(
+            new VolumeMapping(root, @"\\?\Volume{one}\", @"\Device\HarddiskVolume1"),
+            new VolumeMapping(mountPoint, @"\\?\Volume{ten}\", @"\Device\HarddiskVolume10"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                helper.DosDevicePathToPath(@"\Device\HarddiskVolume10\Apps\Game.exe"),
+                Is.EqualTo(Path.Combine(mountPoint, "Apps", "Game.exe")));
+            Assert.That(
+                helper.DosDevicePathToPath(@"\Device\HarddiskVolume1\Apps\Game.exe"),
+                Is.EqualTo(Path.Combine(root, "Apps", "Game.exe")));
+        });
+    }
+
+    [Test]
+    public void DosDevicePathToPath_ReturnsNull_WhenOnlyShorterVolumeNumberIsRegistered()
+    {
+        string root = Path.GetPathRoot(TestContext.CurrentContext.WorkDirectory)!;
+        VolumeHelper helper = CreateHelper(
+            new VolumeMapping(root, @"\\?\Volume{one}\", @"\Device\HarddiskVolume1"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                helper.DosDevicePathToPath(@"\Device\HarddiskVolume10\Game.exe", throwOnError: false),
+                Is.Null);
+            Assert.That(
+                () => helper.DosDevicePathToPath(@"\Device\HarddiskVolume10\Game.exe"),
+                Throws.ArgumentException);
+        });
+    }
+
+    [Test]
+    public void DosDevicePathToPath_ReturnsNull_WhenNoMappingMatchesAndThrowOnErrorIsFalse()
+    {
+        string root = Path.GetPathRoot(TestContext.CurrentContext.WorkDirectory)!;
+        VolumeHelper helper = CreateHelper(
+            new VolumeMapping(root, @"\\?\Volume{root}\", @"\Device\HarddiskVolume1"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(helper.DosDevicePathToPath(@"\Device\Mup\Share\Game.exe", throwOnError: false), Is.Null);
+            Assert.That(() => helper.DosDevicePathToPath(@"\Device\Mup\Share\Game.exe"), Throws.ArgumentException);
+        });
+    }
+
+    [Test]
+    public void DosDevicePathToPath_ResolvesDevicePathWithAndWithoutTrailingSeparator()
+    {
+        string root = Path.GetPathRoot(TestContext.CurrentContext.WorkDirectory)!;
+        VolumeHelper helper = CreateHelper(
+            new VolumeMapping(root, @"\\?\Volume{root}\", @"\Device\HarddiskVolume1"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(helper.DosDevicePathToPath(@"\Device\HarddiskVolume1"), Is.EqualTo(root));
+            Assert.That(helper.DosDevicePathToPath(@"\Device\HarddiskVolume1\"), Is.EqualTo(root));
+        });
+    }
+
+    [Test]
+    public void PathConversions_RoundTripMountedFolderMapping()
+    {
+        using TempFile tempFile = TempFile.Create("Application.exe", "mounted", "nested");
+        string root = Path.GetPathRoot(tempFile.Path)!;
+        string mountPoint = Path.GetDirectoryName(Path.GetDirectoryName(tempFile.Path)!)! + Path.DirectorySeparatorChar;
+
+        VolumeHelper helper = CreateHelper(
+            new VolumeMapping(root, @"\\?\Volume{root}\", @"\Device\HarddiskVolume1"),
+            new VolumeMapping(mountPoint, @"\\?\Volume{mount}\", @"\Device\HarddiskVolume2"));
+
+        string? devicePath = helper.PathToDosDevicePath(tempFile.Path);
+        string? path = helper.DosDevicePathToPath(devicePath!);
+        string? roundTripDevicePath = helper.PathToDosDevicePath(path!);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(devicePath, Is.EqualTo(@"\Device\HarddiskVolume2\nested\Application.exe"));
+            Assert.That(path, Is.EqualTo(tempFile.Path));
+            Assert.That(roundTripDevicePath, Is.EqualTo(devicePath));
+        });
+    }
+
+    [Test]
+    public void ParseMultiString_ReturnsIndividualMountPoints()
+    {
+        string value = "D:\\" + '\0' + "D:\\Mounted\\Steam\\" + '\0' + '\0';
+
+        IReadOnlyList<string> result = VolumeHelper.ParseMultiString(value);
+
+        Assert.That(result, Is.EqualTo(new[] { @"D:\", @"D:\Mounted\Steam\" }));
+    }
+
+    [Test]
+    public void ParseMultiString_ReturnsEmptyList_WhenVolumeHasNoMountPoints()
+    {
+        string value = new('\0', 1);
+
+        IReadOnlyList<string> result = VolumeHelper.ParseMultiString(value);
+
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void WindowsProvider_EnumeratesSystemDriveMapping()
+    {
+        string systemRoot = Path.GetPathRoot(Environment.SystemDirectory)!;
+
+        IReadOnlyList<VolumeMapping> mappings = new WindowsVolumeMappingProvider().GetVolumeMappings();
+
+        VolumeMapping? systemMapping = mappings.FirstOrDefault(m =>
+            m.MountPoint.Equals(systemRoot, StringComparison.OrdinalIgnoreCase));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(systemMapping, Is.Not.Null);
+            Assert.That(systemMapping!.DevicePath, Does.StartWith(@"\Device\"));
+            Assert.That(mappings.Select(m => m.DevicePath), Has.None.Contains(@"\;"));
+        });
+    }
+
+    private static VolumeHelper CreateHelper(params VolumeMapping[] mappings)
+    {
+        return new VolumeHelper(null, new TestVolumeMappingProvider(mappings));
+    }
+
+    private sealed class TestVolumeMappingProvider : IVolumeMappingProvider
+    {
+        private readonly IReadOnlyList<VolumeMapping> _mappings;
+
+        public TestVolumeMappingProvider(IReadOnlyList<VolumeMapping> mappings)
+        {
+            _mappings = mappings;
+        }
+
+        public IReadOnlyList<VolumeMapping> GetVolumeMappings()
+        {
+            return _mappings;
+        }
+    }
+
+    private sealed class TempFile : IDisposable
+    {
+        private readonly string _directory;
+
+        private TempFile(string directory, string path)
+        {
+            _directory = directory;
+            Path = path;
+        }
+
+        public string Path { get; }
+
+        public static TempFile Create(string fileName, params string[] subdirectories)
+        {
+            string directory = System.IO.Path.Combine(
+                TestContext.CurrentContext.WorkDirectory,
+                "VolumeHelperTests",
+                Guid.NewGuid().ToString("N"));
+            string rootDirectory = directory;
+
+            foreach (string subdirectory in subdirectories)
+            {
+                directory = System.IO.Path.Combine(directory, subdirectory);
+            }
+
+            Directory.CreateDirectory(directory);
+            string path = System.IO.Path.Combine(directory, fileName);
+            File.WriteAllText(path, string.Empty);
+
+            return new TempFile(rootDirectory, path);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_directory))
+            {
+                Directory.Delete(_directory, recursive: true);
+            }
+
+            try
+            {
+                // Remove the shared parent directory once the last test directory is gone
+                Directory.Delete(System.IO.Path.GetDirectoryName(_directory)!, recursive: false);
+            }
+            catch (IOException)
+            {
+                // Another test still owns a sibling directory; leave the shared parent in place
+            }
+        }
+    }
+}

--- a/Tests/VolumeHelperTests.cs
+++ b/Tests/VolumeHelperTests.cs
@@ -102,16 +102,19 @@ internal sealed class VolumeHelperTests
     }
 
     [Test]
-    public void DosDevicePathToPath_UsesFirstMappingOnEqualDevicePaths()
+    public void DosDevicePathToPath_PrefersLongestMountPointOnEqualDevicePaths()
     {
+        // When two mount points share the same device path, the one with the longer (more specific)
+        // mount point path should be chosen to keep round-trips deterministic.
         string root = Path.GetPathRoot(TestContext.CurrentContext.WorkDirectory)!;
+        string mountPoint = root.TrimEnd(Path.DirectorySeparatorChar) + @"\Mount\";
         VolumeHelper helper = CreateHelper(
             new VolumeMapping(root, @"\\?\Volume{root}\", @"\Device\HarddiskVolume1"),
-            new VolumeMapping(root.TrimEnd(Path.DirectorySeparatorChar) + @"\Mount\", @"\\?\Volume{mount}\", @"\Device\HarddiskVolume1"));
+            new VolumeMapping(mountPoint, @"\\?\Volume{mount}\", @"\Device\HarddiskVolume1"));
 
         string? result = helper.DosDevicePathToPath(@"\Device\HarddiskVolume1\Apps\DSX.exe");
 
-        Assert.That(result, Is.EqualTo(Path.Combine(root, "Apps", "DSX.exe")));
+        Assert.That(result, Is.EqualTo(Path.Combine(mountPoint, "Apps", "DSX.exe")));
     }
 
     [Test]
@@ -265,6 +268,54 @@ internal sealed class VolumeHelperTests
         });
     }
 
+    [Test]
+    public void VolumeHelper_CallsGetVolumeMappingsOnce_PerInstance()
+    {
+        using TempFile tempFile = TempFile.Create("Application.exe");
+        string root = Path.GetPathRoot(tempFile.Path)!;
+
+        CountingProvider provider = new(
+            new VolumeMapping(root, @"\\?\Volume{root}\", @"\Device\HarddiskVolume1"));
+
+        VolumeHelper helper = new(null, provider);
+
+        string? devicePath = helper.PathToDosDevicePath(tempFile.Path, throwOnError: false);
+        _ = helper.PathToDosDevicePath(tempFile.Path, throwOnError: false);
+        _ = helper.DosDevicePathToPath(devicePath!, throwOnError: false);
+
+        Assert.That(provider.CallCount, Is.EqualTo(1),
+            "GetVolumeMappings should be called exactly once per VolumeHelper instance regardless of how many translation calls are made.");
+    }
+
+    [Test]
+    public void VolumeHelper_PropagatesWin32Exception_EvenWhenThrowOnErrorIsFalse()
+    {
+        VolumeHelper helper = new(null, new ThrowingProvider());
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(() => helper.PathToDosDevicePath(@"C:\nonexistent\App.exe", throwOnError: false),
+                Throws.InstanceOf<System.ComponentModel.Win32Exception>());
+            Assert.That(() => helper.DosDevicePathToPath(@"\Device\HarddiskVolume1\App.exe", throwOnError: false),
+                Throws.InstanceOf<System.ComponentModel.Win32Exception>());
+        });
+    }
+
+    [Test]
+    public void DosDevicePathToPath_PrefersLongestMountPoint_EvenWhenRegisteredInReversedOrder()
+    {
+        // Verify the tie-break also works when the shorter mount point appears second in the list.
+        string root = Path.GetPathRoot(TestContext.CurrentContext.WorkDirectory)!;
+        string mountPoint = root.TrimEnd(Path.DirectorySeparatorChar) + @"\Mount\";
+        VolumeHelper helper = CreateHelper(
+            new VolumeMapping(mountPoint, @"\\?\Volume{mount}\", @"\Device\HarddiskVolume1"),
+            new VolumeMapping(root, @"\\?\Volume{root}\", @"\Device\HarddiskVolume1"));
+
+        string? result = helper.DosDevicePathToPath(@"\Device\HarddiskVolume1\Apps\DSX.exe");
+
+        Assert.That(result, Is.EqualTo(Path.Combine(mountPoint, "Apps", "DSX.exe")));
+    }
+
     private static VolumeHelper CreateHelper(params VolumeMapping[] mappings)
     {
         return new VolumeHelper(null, new TestVolumeMappingProvider(mappings));
@@ -282,6 +333,32 @@ internal sealed class VolumeHelperTests
         public IReadOnlyList<VolumeMapping> GetVolumeMappings()
         {
             return _mappings;
+        }
+    }
+
+    private sealed class CountingProvider : IVolumeMappingProvider
+    {
+        private readonly IReadOnlyList<VolumeMapping> _mappings;
+
+        public CountingProvider(params VolumeMapping[] mappings)
+        {
+            _mappings = mappings;
+        }
+
+        public int CallCount { get; private set; }
+
+        public IReadOnlyList<VolumeMapping> GetVolumeMappings()
+        {
+            CallCount++;
+            return _mappings;
+        }
+    }
+
+    private sealed class ThrowingProvider : IVolumeMappingProvider
+    {
+        public IReadOnlyList<VolumeMapping> GetVolumeMappings()
+        {
+            throw new System.ComponentModel.Win32Exception(2);
         }
     }
 

--- a/src/HidHideControlService.cs
+++ b/src/HidHideControlService.cs
@@ -492,13 +492,17 @@ public sealed class HidHideControlService : IHidHideControlService
         {
             using SafeFileHandle handle = OpenControlDeviceHandle().HaltAndCatchFireOnError();
 
-            buffer = GetApplications(handle)
-                .Concat([path]) // Add our own instance paths to the existing list
-                .Distinct() // Remove duplicates, if any
-                .Select(p =>
-                    new VolumeHelper(_loggerFactory?.CreateLogger<VolumeHelper>())
-                        .PathToDosDevicePath(p, false)) // re-convert to dos paths
-                .Where(r => !string.IsNullOrEmpty(r)) // strip invalid entries
+            // Win32Exception from volume enumeration intentionally propagates (aborts before any write).
+            VolumeHelper vh = new(_loggerFactory?.CreateLogger<VolumeHelper>());
+
+            // Operate in device-path space: read the raw list, append the new device path, dedup,
+            // and write back unchanged — no lossy reverse round-trip for existing entries.
+            string? targetDevicePath = vh.PathToDosDevicePath(path, false);
+
+            buffer = GetRawApplications(handle)
+                .Concat(targetDevicePath is null ? [] : [targetDevicePath])
+                .Where(r => !string.IsNullOrEmpty(r))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
                 .StringArrayToMultiSzPointer(out int length); // Convert to usable buffer
 
             if (length >= short.MaxValue)
@@ -545,13 +549,26 @@ public sealed class HidHideControlService : IHidHideControlService
         {
             using SafeFileHandle handle = OpenControlDeviceHandle().HaltAndCatchFireOnError();
 
-            buffer = GetApplications(handle)
-                .Where(i => !i.Equals(path, StringComparison.OrdinalIgnoreCase))
-                .Distinct() // Remove duplicates, if any
-                .Select(p =>
-                    new VolumeHelper(_loggerFactory?.CreateLogger<VolumeHelper>())
-                        .PathToDosDevicePath(p, false)) // re-convert to dos paths
-                .Where(r => !string.IsNullOrEmpty(r)) // strip invalid entries
+            // Win32Exception from volume enumeration intentionally propagates (aborts before any write).
+            VolumeHelper vh = new(_loggerFactory?.CreateLogger<VolumeHelper>());
+
+            // Convert the target path to its device path so the comparison happens in device-path space.
+            // This avoids the lossy reverse round-trip (device->user->device) that breaks removal when
+            // one volume is mounted at multiple locations.
+            string? targetDevicePath = vh.PathToDosDevicePath(path, false);
+
+            IReadOnlyList<string> rawApps = GetRawApplications(handle);
+
+            IEnumerable<string> remaining = targetDevicePath is not null
+                // Happy path: filter raw device paths directly — no reverse conversion needed.
+                ? rawApps.Where(d => !d.Equals(targetDevicePath, StringComparison.OrdinalIgnoreCase))
+                // Fallback: file no longer exists so PathToDosDevicePath returned null; fall back to
+                // comparing via the reverse translation so we still remove a stale entry if possible.
+                : rawApps.Where(d => !string.Equals(
+                    vh.DosDevicePathToPath(d, false), path, StringComparison.OrdinalIgnoreCase));
+
+            buffer = remaining
+                .Distinct()
                 .StringArrayToMultiSzPointer(out int length); // Convert to usable buffer
 
             if (length >= short.MaxValue)
@@ -641,7 +658,7 @@ public sealed class HidHideControlService : IHidHideControlService
         );
     }
 
-    private unsafe IReadOnlyList<string> GetApplications(SafeHandle handle)
+    private unsafe IReadOnlyList<string> GetRawApplications(SafeHandle handle)
     {
         IntPtr buffer = IntPtr.Zero;
 
@@ -674,7 +691,6 @@ public sealed class HidHideControlService : IHidHideControlService
             buffer = Marshal.AllocHGlobal((int)required);
 
             // Get actual buffer content
-            // Check return value for success
             ret = PInvoke.DeviceIoControl(
                 new HANDLE(handle.DangerousGetHandle()),
                 IoctlGetWhitelist,
@@ -691,17 +707,7 @@ public sealed class HidHideControlService : IHidHideControlService
                 throw new HidHideRequestFailedException();
             }
 
-            // Store existing blocklist in a more manageable "C#" fashion
-            List<string?> list = buffer
-                .MultiSzPointerToStringArray((int)required)
-                .Select(p =>
-                    new VolumeHelper(_loggerFactory?.CreateLogger<VolumeHelper>()).DosDevicePathToPath(p, false))
-                .Where(r => !string.IsNullOrEmpty(r))
-                .ToList();
-
-            _logger?.LogDebug("Got applications: {@AppList}", list);
-
-            return list!;
+            return buffer.MultiSzPointerToStringArray((int)required).ToList();
         }
         finally
         {
@@ -710,6 +716,21 @@ public sealed class HidHideControlService : IHidHideControlService
                 Marshal.FreeHGlobal(buffer);
             }
         }
+    }
+
+    private IReadOnlyList<string> GetApplications(SafeHandle handle)
+    {
+        // Win32Exception from volume enumeration intentionally propagates.
+        VolumeHelper vh = new(_loggerFactory?.CreateLogger<VolumeHelper>());
+
+        List<string?> list = GetRawApplications(handle)
+            .Select(p => vh.DosDevicePathToPath(p, false))
+            .Where(r => !string.IsNullOrEmpty(r))
+            .ToList();
+
+        _logger?.LogDebug("Got applications: {@AppList}", list);
+
+        return list!;
     }
 
     private unsafe IReadOnlyList<string> GetBlockedInstances(SafeHandle handle)

--- a/src/NativeMethods.txt
+++ b/src/NativeMethods.txt
@@ -3,6 +3,7 @@ DeviceIoControl
 GetVolumePathNamesForVolumeNameW
 FindFirstVolume
 FindNextVolume
+FindVolumeClose
 QueryDosDevice
 METHOD_BUFFERED 
 METHOD_IN_DIRECT

--- a/src/Nefarius.Drivers.HidHide.csproj
+++ b/src/Nefarius.Drivers.HidHide.csproj
@@ -17,6 +17,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="Tests" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
         <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.281">

--- a/src/Util/VolumeHelper.cs
+++ b/src/Util/VolumeHelper.cs
@@ -79,12 +79,7 @@ internal class VolumeHelper
     ///     Translates a "DOS device" path to user-land path.
     /// </summary>
     /// <param name="devicePath">The DOS device path to convert.</param>
-    /// <param name="throwOnError">
-    ///     When true, throws <see cref="ArgumentException" /> if no matching mount point is found.
-    ///     When false, returns null instead. Note: <paramref name="throwOnError" /> only governs path
-    ///     translation failures. A <see cref="System.ComponentModel.Win32Exception" /> raised by the
-    ///     underlying volume enumeration always propagates regardless of this flag.
-    /// </param>
+    /// <param name="throwOnError">Throw exception on any sort of parsing error if true, false returns null.</param>
     /// <returns>The user-land path.</returns>
     public string? DosDevicePathToPath(string devicePath, bool throwOnError = true)
     {
@@ -166,12 +161,7 @@ internal class VolumeHelper
     ///     Translates a user-land file path to "DOS device" path.
     /// </summary>
     /// <param name="path">The file path in normal namespace format.</param>
-    /// <param name="throwOnError">
-    ///     When true, throws on parse/translation failures (file not found, no matching mount point).
-    ///     When false, returns null instead. Note: <paramref name="throwOnError" /> only governs path
-    ///     translation failures. A <see cref="System.ComponentModel.Win32Exception" /> raised by the
-    ///     underlying volume enumeration always propagates regardless of this flag.
-    /// </param>
+    /// <param name="throwOnError">Throw exception on any sort of parsing error if true, false returns null.</param>
     /// <returns>The device namespace path (DOS device).</returns>
     public string? PathToDosDevicePath(string path, bool throwOnError = true)
     {

--- a/src/Util/VolumeHelper.cs
+++ b/src/Util/VolumeHelper.cs
@@ -23,6 +23,7 @@ internal class VolumeHelper
 {
     private readonly ILogger<VolumeHelper>? _logger;
     private readonly IVolumeMappingProvider _volumeMappingProvider;
+    private IReadOnlyList<VolumeMapping>? _mappings;
 
     internal VolumeHelper(ILogger<VolumeHelper>? logger)
         : this(logger, new WindowsVolumeMappingProvider())
@@ -34,6 +35,9 @@ internal class VolumeHelper
         _logger = logger;
         _volumeMappingProvider = volumeMappingProvider;
     }
+
+    private IReadOnlyList<VolumeMapping> GetMappings()
+        => _mappings ??= _volumeMappingProvider.GetVolumeMappings();
 
     /// <summary>
     ///     Splits Win32 MULTI_SZ buffer content into individual entries.
@@ -75,7 +79,12 @@ internal class VolumeHelper
     ///     Translates a "DOS device" path to user-land path.
     /// </summary>
     /// <param name="devicePath">The DOS device path to convert.</param>
-    /// <param name="throwOnError">Throw exception on any sort of parsing error if true, false returns null.</param>
+    /// <param name="throwOnError">
+    ///     When true, throws <see cref="ArgumentException" /> if no matching mount point is found.
+    ///     When false, returns null instead. Note: <paramref name="throwOnError" /> only governs path
+    ///     translation failures. A <see cref="System.ComponentModel.Win32Exception" /> raised by the
+    ///     underlying volume enumeration always propagates regardless of this flag.
+    /// </param>
     /// <returns>The user-land path.</returns>
     public string? DosDevicePathToPath(string devicePath, bool throwOnError = true)
     {
@@ -84,7 +93,7 @@ internal class VolumeHelper
         VolumeMapping? bestMapping = null;
         string? bestDevicePath = null;
 
-        foreach (VolumeMapping current in _volumeMappingProvider.GetVolumeMappings())
+        foreach (VolumeMapping current in GetMappings())
         {
             if (string.IsNullOrWhiteSpace(current.MountPoint) || string.IsNullOrWhiteSpace(current.DevicePath))
             {
@@ -109,7 +118,14 @@ internal class VolumeHelper
                 continue;
             }
 
-            if (bestDevicePath is null || currentDevicePath.Length > bestDevicePath.Length)
+            // Prefer the longer device path; on equal length prefer the longer mount point so that
+            // display is deterministic when one volume is mounted at multiple locations.
+            bool isBetter = bestDevicePath is null ||
+                            currentDevicePath.Length > bestDevicePath.Length ||
+                            (currentDevicePath.Length == bestDevicePath.Length &&
+                             current.MountPoint.Length > bestMapping!.MountPoint.Length);
+
+            if (isBetter)
             {
                 bestMapping = current;
                 bestDevicePath = currentDevicePath;
@@ -150,7 +166,12 @@ internal class VolumeHelper
     ///     Translates a user-land file path to "DOS device" path.
     /// </summary>
     /// <param name="path">The file path in normal namespace format.</param>
-    /// <param name="throwOnError">Throw exception on any sort of parsing error if true, false returns null.</param>
+    /// <param name="throwOnError">
+    ///     When true, throws on parse/translation failures (file not found, no matching mount point).
+    ///     When false, returns null instead. Note: <paramref name="throwOnError" /> only governs path
+    ///     translation failures. A <see cref="System.ComponentModel.Win32Exception" /> raised by the
+    ///     underlying volume enumeration always propagates regardless of this flag.
+    /// </param>
     /// <returns>The device namespace path (DOS device).</returns>
     public string? PathToDosDevicePath(string path, bool throwOnError = true)
     {
@@ -189,7 +210,7 @@ internal class VolumeHelper
         VolumeMapping? bestMapping = null;
         string? bestMountPoint = null;
 
-        foreach (VolumeMapping current in _volumeMappingProvider.GetVolumeMappings())
+        foreach (VolumeMapping current in GetMappings())
         {
             if (string.IsNullOrWhiteSpace(current.MountPoint) || string.IsNullOrWhiteSpace(current.DevicePath))
             {

--- a/src/Util/VolumeHelper.cs
+++ b/src/Util/VolumeHelper.cs
@@ -2,10 +2,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security;
 using System.Text;
-using System.Text.RegularExpressions;
 
 using Windows.Win32;
 using Windows.Win32.Foundation;
@@ -19,134 +21,105 @@ namespace Nefarius.Drivers.HidHide.Util;
 /// </summary>
 internal class VolumeHelper
 {
-    private static readonly Regex ExtractDevicePathPrefixRegex = new(@"^(\\Device\\HarddiskVolume\d*)\\.*");
     private readonly ILogger<VolumeHelper>? _logger;
+    private readonly IVolumeMappingProvider _volumeMappingProvider;
 
     internal VolumeHelper(ILogger<VolumeHelper>? logger)
+        : this(logger, new WindowsVolumeMappingProvider())
+    {
+    }
+
+    internal VolumeHelper(ILogger<VolumeHelper>? logger, IVolumeMappingProvider volumeMappingProvider)
     {
         _logger = logger;
+        _volumeMappingProvider = volumeMappingProvider;
     }
 
     /// <summary>
-    ///     Curates and returns a collection of volume to path mappings.
+    ///     Splits Win32 MULTI_SZ buffer content into individual entries.
     /// </summary>
-    /// <returns>A collection of <see cref="VolumeMeta" />.</returns>
-    private static unsafe IEnumerable<VolumeMeta> GetVolumeMappings()
+    /// <param name="value">The MULTI_SZ string.</param>
+    /// <returns>The non-empty entries.</returns>
+    internal static IReadOnlyList<string> ParseMultiString(string value)
     {
-        char[] volumeName = new char[ushort.MaxValue];
-        char[] pathName = new char[ushort.MaxValue];
-        char[] mountPoint = new char[ushort.MaxValue];
-
-        fixed (char* pVolumeName = volumeName)
-        fixed (char* pPathName = pathName)
-        fixed (char* pMountPoint = mountPoint)
-        {
-            HANDLE volumeHandle = PInvoke.FindFirstVolume(pVolumeName, ushort.MaxValue);
-
-            List<VolumeMeta> list = new();
-
-            do
-            {
-                string volume = new string(volumeName).TrimEnd('\0');
-
-                if (!PInvoke.GetVolumePathNamesForVolumeName(
-                        volume,
-                        pMountPoint,
-                        ushort.MaxValue,
-                        out uint returnLength
-                    ))
-                {
-                    continue;
-                }
-
-                // Extract volume name for use with QueryDosDevice
-                string deviceName = volume.Substring(4, volume.Length - 1 - 4);
-
-                fixed (char* pDeviceName = deviceName)
-                {
-                    // Grab the device path
-                    returnLength = PInvoke.QueryDosDevice(pDeviceName, pPathName, ushort.MaxValue);
-                }
-
-                if (returnLength <= 0)
-                {
-                    continue;
-                }
-
-                VolumeMeta entry = new()
-                {
-                    DriveLetter = new string(mountPoint).TrimEnd('\0'),
-                    VolumeName = volume,
-                    DevicePath = new string(pathName).TrimEnd('\0')
-                };
-
-                list.Add(entry);
-            } while (PInvoke.FindNextVolume(volumeHandle, pVolumeName, ushort.MaxValue));
-
-            return list.ToArray();
-        }
+        return value
+            .Split('\0')
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .ToArray();
     }
 
     /// <summary>
-    ///     Checks if a path is a junction point.
-    /// </summary>
-    /// <param name="di">A <see cref="FileSystemInfo" /> instance.</param>
-    /// <returns>True if it's a junction, false otherwise.</returns>
-    private static bool IsPathReparsePoint(FileSystemInfo di)
-    {
-        return di.Attributes.HasFlag(FileAttributes.ReparsePoint);
-    }
-
-    /// <summary>
-    ///     Helper to make paths comparable.
+    ///     Canonicalizes a path so matching and relative-path extraction operate on the same string.
     /// </summary>
     /// <param name="path">The source path.</param>
-    /// <returns>The normalized path.</returns>
-    private static string NormalizePath(string path)
+    /// <returns>The fully qualified path, or null if the path cannot be resolved.</returns>
+    private static string? TryGetFullPath(string path)
     {
-        return Path
-            .GetFullPath(new Uri(path).LocalPath)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-            .ToUpperInvariant();
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return Path.GetFullPath(path);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException
+                                       or SecurityException)
+        {
+            return null;
+        }
     }
 
     /// <summary>
     ///     Translates a "DOS device" path to user-land path.
     /// </summary>
     /// <param name="devicePath">The DOS device path to convert.</param>
-    /// <param name="throwOnError">Throw exception on any sort of parsing error if true, false returns empty string.</param>
+    /// <param name="throwOnError">Throw exception on any sort of parsing error if true, false returns null.</param>
     /// <returns>The user-land path.</returns>
     public string? DosDevicePathToPath(string devicePath, bool throwOnError = true)
     {
         _logger?.LogDebug("++ Resolving DOS device path {DevicePath} to path", devicePath);
 
-        //
-        // TODO: cover and test junctions!
-        // 
+        VolumeMapping? bestMapping = null;
+        string? bestDevicePath = null;
 
-        Match prefixMatch = ExtractDevicePathPrefixRegex.Match(devicePath);
-
-        if (!prefixMatch.Success)
+        foreach (VolumeMapping current in _volumeMappingProvider.GetVolumeMappings())
         {
-            _logger?.LogDebug("Prefix {Prefix} didn't match path {DevicePath}",
-                ExtractDevicePathPrefixRegex, devicePath);
-
-            if (throwOnError)
+            if (string.IsNullOrWhiteSpace(current.MountPoint) || string.IsNullOrWhiteSpace(current.DevicePath))
             {
-                throw new ArgumentException("Failed to parse provided device path prefix");
+                continue;
             }
 
-            return null;
+            string currentDevicePath = current.DevicePath.TrimEnd(Path.DirectorySeparatorChar);
+
+            if (currentDevicePath.Length == 0)
+            {
+                continue;
+            }
+
+            // Boundary-checked prefix match so e.g. HarddiskVolume1 never claims HarddiskVolume10 paths
+            bool isMatch =
+                devicePath.Equals(currentDevicePath, StringComparison.OrdinalIgnoreCase) ||
+                devicePath.StartsWith(currentDevicePath + Path.DirectorySeparatorChar,
+                    StringComparison.OrdinalIgnoreCase);
+
+            if (!isMatch)
+            {
+                continue;
+            }
+
+            if (bestDevicePath is null || currentDevicePath.Length > bestDevicePath.Length)
+            {
+                bestMapping = current;
+                bestDevicePath = currentDevicePath;
+            }
         }
 
-        string prefix = prefixMatch.Groups[1].Value;
-        _logger?.LogDebug("Extracted prefix: {Prefix}", prefix);
-
-        VolumeMeta? mapping = GetVolumeMappings()
-            .SingleOrDefault(m => prefix.Equals(m.DevicePath));
-
-        if (mapping is null)
+        if (bestMapping is null || bestDevicePath is null)
         {
+            _logger?.LogDebug("No volume mapping matched device path {DevicePath}", devicePath);
+
             if (throwOnError)
             {
                 throw new ArgumentException("Failed to translate provided path");
@@ -155,13 +128,18 @@ internal class VolumeHelper
             return null;
         }
 
-        string relativePath = devicePath
-            .Replace(mapping.DevicePath, string.Empty)
-            .TrimStart(Path.DirectorySeparatorChar);
+        string relativePath = devicePath.Length > bestDevicePath.Length
+            ? devicePath.Substring(bestDevicePath.Length).TrimStart(Path.DirectorySeparatorChar)
+            : string.Empty;
 
         _logger?.LogDebug("Built relative path: {Path}", relativePath);
 
-        string fullPath = Path.Combine(mapping.DriveLetter, relativePath);
+        // Concatenate instead of Path.Combine so a remainder that merely looks rooted
+        // (e.g. "C:evil.exe" from a corrupt blocklist entry) can't discard the mount point
+        string fullPath =
+            bestMapping.MountPoint.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) +
+            Path.DirectorySeparatorChar +
+            relativePath;
 
         _logger?.LogDebug("-- Returning path {Path} for device path {DevicePath}", fullPath, devicePath);
 
@@ -172,11 +150,15 @@ internal class VolumeHelper
     ///     Translates a user-land file path to "DOS device" path.
     /// </summary>
     /// <param name="path">The file path in normal namespace format.</param>
-    /// <param name="throwOnError">Throw exception on any sort of parsing error if true, false returns empty string.</param>
+    /// <param name="throwOnError">Throw exception on any sort of parsing error if true, false returns null.</param>
     /// <returns>The device namespace path (DOS device).</returns>
     public string? PathToDosDevicePath(string path, bool throwOnError = true)
     {
         _logger?.LogDebug("++ Resolving path {Path} to DOS device path", path);
+
+        //
+        // TODO: cover and test junctions!
+        //
 
         if (!File.Exists(path))
         {
@@ -190,65 +172,63 @@ internal class VolumeHelper
             return null;
         }
 
-        string filePart = Path.GetFileName(path);
-        _logger?.LogDebug("File part: {File}", filePart);
-        string? pathPart = Path.GetDirectoryName(path);
-        _logger?.LogDebug("Directory part: {Path}", pathPart);
+        string? fullPath = TryGetFullPath(path);
 
-        if (string.IsNullOrEmpty(pathPart))
+        if (fullPath is null)
         {
-            _logger?.LogWarning("Directory part of path was empty");
+            _logger?.LogWarning("Failed to canonicalize path {Path}", path);
 
             if (throwOnError)
             {
-                throw new IOException($"Couldn't resolve directory of path {path}");
+                throw new IOException($"Couldn't canonicalize path {path}");
             }
 
             return null;
         }
 
-        string pathNoRoot = string.Empty;
-        string? devicePath = string.Empty;
+        VolumeMapping? bestMapping = null;
+        string? bestMountPoint = null;
 
-        // Walk up the directory tree to get the "deepest" potential junction
-        for (DirectoryInfo? current = new(pathPart);
-             current is { Exists: true };
-             current = Directory.GetParent(current.FullName))
+        foreach (VolumeMapping current in _volumeMappingProvider.GetVolumeMappings())
         {
-            if (!IsPathReparsePoint(current))
+            if (string.IsNullOrWhiteSpace(current.MountPoint) || string.IsNullOrWhiteSpace(current.DevicePath))
             {
-                _logger?.LogDebug("Path {Path} is not a reparse point", current);
                 continue;
             }
 
-            devicePath = GetVolumeMappings()
-                .SingleOrDefault(m =>
-                    !string.IsNullOrEmpty(m.DriveLetter) &&
-                    NormalizePath(m.DriveLetter) == NormalizePath(current.FullName))
-                ?.DevicePath;
-            _logger?.LogDebug("Mapped current path node {Path} to device path {DevicePath}", current, devicePath);
+            string? mountPointFullPath = TryGetFullPath(current.MountPoint);
 
-            pathNoRoot = pathPart.Substring(current.FullName.Length);
-            _logger?.LogDebug("Set root-less path to {Path}", pathNoRoot);
+            if (mountPointFullPath is null)
+            {
+                _logger?.LogDebug("Skipping unusable mount point {MountPoint}", current.MountPoint);
+                continue;
+            }
 
-            break;
+            string mountPoint = mountPointFullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+            if (mountPoint.Length == 0)
+            {
+                continue;
+            }
+
+            bool isMatch =
+                fullPath.Equals(mountPoint, StringComparison.OrdinalIgnoreCase) ||
+                fullPath.StartsWith(mountPoint + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+
+            if (!isMatch)
+            {
+                continue;
+            }
+
+            // Prefer the longest (deepest) mount point so mounted folders win over the volume root
+            if (bestMountPoint is null || mountPoint.Length > bestMountPoint.Length)
+            {
+                bestMapping = current;
+                bestMountPoint = mountPoint;
+            }
         }
 
-        // No junctions found, translate original path
-        if (string.IsNullOrEmpty(devicePath))
-        {
-            _logger?.LogDebug("No junctions found for path {Path}, resolving directly", path);
-
-            string driveLetter = Path.GetPathRoot(pathPart)!;
-            devicePath = GetVolumeMappings()
-                .SingleOrDefault(m =>
-                    m.DriveLetter.Equals(driveLetter, StringComparison.InvariantCultureIgnoreCase))?.DevicePath;
-            _logger?.LogDebug("Mapped path {Path} to device path {DevicePath}", path, devicePath);
-            pathNoRoot = pathPart.Substring(Path.GetPathRoot(pathPart)!.Length);
-            _logger?.LogDebug("Set root-less path to {Path}", pathNoRoot);
-        }
-
-        if (string.IsNullOrEmpty(devicePath))
+        if (bestMapping is null || bestMountPoint is null)
         {
             _logger?.LogWarning("Failed to resolve path {Path}", path);
 
@@ -260,23 +240,311 @@ internal class VolumeHelper
             return null;
         }
 
-        StringBuilder fullDevicePath = new();
+        string relativePath = fullPath.Length > bestMountPoint.Length
+            ? fullPath.Substring(bestMountPoint.Length).TrimStart(Path.DirectorySeparatorChar)
+            : string.Empty;
 
-        // Build new DOS Device path
-        fullDevicePath.AppendFormat("{0}{1}", devicePath, Path.DirectorySeparatorChar);
-        fullDevicePath.Append(Path.Combine(pathNoRoot, filePart).TrimStart(Path.DirectorySeparatorChar));
+        _logger?.LogDebug("Built relative path: {Path}", relativePath);
+
+        StringBuilder fullDevicePath = new();
+        fullDevicePath.Append(bestMapping.DevicePath.TrimEnd(Path.DirectorySeparatorChar));
+        fullDevicePath.Append(Path.DirectorySeparatorChar);
+        fullDevicePath.Append(relativePath);
 
         _logger?.LogDebug("-- Returning device path {DevicePath} for path {Path}", fullDevicePath, path);
 
         return fullDevicePath.ToString();
     }
+}
 
-    private class VolumeMeta
+/// <summary>
+///     Supplies volume to mount point mappings.
+/// </summary>
+internal interface IVolumeMappingProvider
+{
+    /// <summary>
+    ///     Gets one mapping per volume mount point; volumes without mount points are not included.
+    /// </summary>
+    /// <exception cref="Win32Exception">Volume enumeration failed.</exception>
+    IReadOnlyList<VolumeMapping> GetVolumeMappings();
+}
+
+/// <summary>
+///     Describes a single volume mount point and its NT device path.
+/// </summary>
+internal sealed class VolumeMapping
+{
+    public VolumeMapping(string mountPoint, string volumeName, string devicePath)
     {
-        public string DriveLetter { get; set; } = null!;
+        MountPoint = mountPoint;
+        VolumeName = volumeName;
+        DevicePath = devicePath;
+    }
 
-        public string VolumeName { get; set; } = null!;
+    /// <summary>
+    ///     The user-land mount point (e.g. "C:\" or "C:\Mount\Data\").
+    /// </summary>
+    public string MountPoint { get; }
 
-        public string DevicePath { get; set; } = null!;
+    /// <summary>
+    ///     The volume GUID path (e.g. "\\?\Volume{...}\"), or an empty string when the mapping was
+    ///     discovered from a DOS device definition instead of the Mount Manager.
+    /// </summary>
+    public string VolumeName { get; }
+
+    /// <summary>
+    ///     The NT device path (e.g. "\Device\HarddiskVolume2").
+    /// </summary>
+    public string DevicePath { get; }
+}
+
+/// <summary>
+///     Queries volume mappings from the running Windows system.
+/// </summary>
+internal sealed class WindowsVolumeMappingProvider : IVolumeMappingProvider
+{
+    private static readonly HANDLE InvalidHandleValue = new(new IntPtr(-1));
+
+    /// <inheritdoc />
+    public unsafe IReadOnlyList<VolumeMapping> GetVolumeMappings()
+    {
+        char[] volumeNameBuffer = new char[ushort.MaxValue];
+        char[] devicePathBuffer = new char[ushort.MaxValue];
+        char[] mountPointsBuffer = new char[ushort.MaxValue];
+
+        fixed (char* pVolumeName = volumeNameBuffer)
+        fixed (char* pDevicePath = devicePathBuffer)
+        fixed (char* pMountPoints = mountPointsBuffer)
+        {
+            List<VolumeMapping> list = new();
+
+            HANDLE volumeHandle = PInvoke.FindFirstVolume(pVolumeName, ushort.MaxValue);
+
+            if (volumeHandle == InvalidHandleValue)
+            {
+                // Distinguish "enumeration failed" from "no volumes": silently returning an empty
+                // list would make callers rewrite the driver blocklist with nothing in it
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            try
+            {
+                do
+                {
+                    string volume = GetNullTerminatedString(volumeNameBuffer);
+
+                    // Volume GUID paths are documented ("Naming a Volume") as \\?\Volume{...}\ with a
+                    // trailing backslash; like the Win32 "Displaying Volume Paths" sample, treat any
+                    // other shape as invalid, but skip it instead of aborting the enumeration.
+                    if (volume.Length < 6 ||
+                        !volume.StartsWith(@"\\?\", StringComparison.Ordinal) ||
+                        volume[volume.Length - 1] != '\\')
+                    {
+                        continue;
+                    }
+
+                    Array.Clear(mountPointsBuffer, 0, mountPointsBuffer.Length);
+                    Array.Clear(devicePathBuffer, 0, devicePathBuffer.Length);
+
+                    if (!PInvoke.GetVolumePathNamesForVolumeName(
+                            volume,
+                            pMountPoints,
+                            ushort.MaxValue,
+                            out uint mountPointsLength
+                        ))
+                    {
+                        continue;
+                    }
+
+                    int usableMountPointsLength = (int)Math.Min(mountPointsLength, (uint)mountPointsBuffer.Length);
+
+                    IReadOnlyList<string> mountPoints = VolumeHelper.ParseMultiString(
+                        new string(mountPointsBuffer, 0, usableMountPointsLength));
+
+                    if (mountPoints.Count == 0)
+                    {
+                        // A volume without mount points can't participate in path translation
+                        continue;
+                    }
+
+                    // Extract the volume name for use with QueryDosDevice (strip "\\?\" prefix and trailing separator)
+                    string deviceName = volume.Substring(4, volume.Length - 1 - 4);
+
+                    uint devicePathLength;
+
+                    fixed (char* pDeviceName = deviceName)
+                    {
+                        devicePathLength = PInvoke.QueryDosDevice(pDeviceName, pDevicePath, ushort.MaxValue);
+                    }
+
+                    if (devicePathLength == 0)
+                    {
+                        continue;
+                    }
+
+                    int usableDevicePathLength = (int)Math.Min(devicePathLength, (uint)devicePathBuffer.Length);
+
+                    // QueryDosDevice returns a MULTI_SZ list; the first entry is the current mapping
+                    string? devicePath = VolumeHelper.ParseMultiString(
+                            new string(devicePathBuffer, 0, usableDevicePathLength))
+                        .FirstOrDefault();
+
+                    if (string.IsNullOrWhiteSpace(devicePath))
+                    {
+                        continue;
+                    }
+
+                    foreach (string mountPoint in mountPoints)
+                    {
+                        list.Add(new VolumeMapping(mountPoint, volume, devicePath!));
+                    }
+                } while (PInvoke.FindNextVolume(volumeHandle, pVolumeName, ushort.MaxValue));
+
+                // FALSE with ERROR_NO_MORE_FILES is the documented normal end of enumeration;
+                // anything else means the list is silently incomplete, so surface it
+                int lastError = Marshal.GetLastWin32Error();
+
+                if (lastError != (int)WIN32_ERROR.ERROR_NO_MORE_FILES)
+                {
+                    throw new Win32Exception(lastError);
+                }
+            }
+            finally
+            {
+                PInvoke.FindVolumeClose(volumeHandle);
+            }
+
+            AppendDosDeviceDriveMappings(list, devicePathBuffer, pDevicePath);
+
+            return list;
+        }
+    }
+
+    /// <summary>
+    ///     Adds mappings for drive letters defined outside the Mount Manager (DefineDosDevice-based
+    ///     drives such as VeraCrypt, ImDisk or SUBST) which FindFirstVolume cannot enumerate.
+    /// </summary>
+    private static unsafe void AppendDosDeviceDriveMappings(List<VolumeMapping> list, char[] devicePathBuffer,
+        char* pDevicePath)
+    {
+        for (char letter = 'A'; letter <= 'Z'; letter++)
+        {
+            string mountPoint = letter + @":\";
+
+            if (list.Any(m => m.MountPoint.Equals(mountPoint, StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            Array.Clear(devicePathBuffer, 0, devicePathBuffer.Length);
+
+            string deviceName = letter + ":";
+            uint devicePathLength;
+
+            fixed (char* pDeviceName = deviceName)
+            {
+                devicePathLength = PInvoke.QueryDosDevice(pDeviceName, pDevicePath, ushort.MaxValue);
+            }
+
+            if (devicePathLength == 0)
+            {
+                // The drive letter is not in use
+                continue;
+            }
+
+            int usableDevicePathLength = (int)Math.Min(devicePathLength, (uint)devicePathBuffer.Length);
+
+            string? target = VolumeHelper.ParseMultiString(
+                    new string(devicePathBuffer, 0, usableDevicePathLength))
+                .FirstOrDefault();
+
+            if (string.IsNullOrWhiteSpace(target))
+            {
+                continue;
+            }
+
+            // One level of \??\ indirection (e.g. SUBST X: C:\Dir) resolves against the
+            // Mount Manager mappings collected above
+            if (target!.StartsWith(@"\??\", StringComparison.Ordinal))
+            {
+                target = ResolveDosPathToDevicePath(list, target.Substring(4));
+
+                if (target is null)
+                {
+                    continue;
+                }
+            }
+
+            // Network redirector targets embed session-specific "\;X:" segments the driver
+            // never sees in image paths; emitting them would create entries that match nothing
+            if (!target.StartsWith(@"\Device\", StringComparison.OrdinalIgnoreCase) ||
+                target.IndexOf(@"\;", StringComparison.Ordinal) >= 0)
+            {
+                continue;
+            }
+
+            list.Add(new VolumeMapping(mountPoint, string.Empty, target));
+        }
+    }
+
+    /// <summary>
+    ///     Translates a DOS path (e.g. "C:\Dir") to its NT device path using already collected mappings.
+    /// </summary>
+    private static string? ResolveDosPathToDevicePath(List<VolumeMapping> mappings, string dosPath)
+    {
+        VolumeMapping? bestMapping = null;
+        string? bestMountPoint = null;
+
+        foreach (VolumeMapping current in mappings)
+        {
+            string mountPoint = current.MountPoint.TrimEnd(Path.DirectorySeparatorChar);
+
+            if (mountPoint.Length == 0)
+            {
+                continue;
+            }
+
+            bool isMatch =
+                dosPath.Equals(mountPoint, StringComparison.OrdinalIgnoreCase) ||
+                dosPath.StartsWith(mountPoint + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+
+            if (!isMatch)
+            {
+                continue;
+            }
+
+            if (bestMountPoint is null || mountPoint.Length > bestMountPoint.Length)
+            {
+                bestMapping = current;
+                bestMountPoint = mountPoint;
+            }
+        }
+
+        if (bestMapping is null || bestMountPoint is null)
+        {
+            return null;
+        }
+
+        string relativePath = dosPath.Length > bestMountPoint.Length
+            ? dosPath.Substring(bestMountPoint.Length).TrimStart(Path.DirectorySeparatorChar)
+            : string.Empty;
+
+        string devicePath = bestMapping.DevicePath.TrimEnd(Path.DirectorySeparatorChar);
+
+        return relativePath.Length == 0 ? devicePath : devicePath + Path.DirectorySeparatorChar + relativePath;
+    }
+
+    /// <summary>
+    ///     Extracts the string content of a fixed-size buffer up to the first NUL terminator.
+    /// </summary>
+    /// <param name="value">The character buffer.</param>
+    /// <returns>The content before the first NUL character, or the whole buffer if none is present.</returns>
+    private static string GetNullTerminatedString(char[] value)
+    {
+        int length = Array.IndexOf(value, '\0');
+
+        return length < 0
+            ? new string(value)
+            : new string(value, 0, length);
     }
 }


### PR DESCRIPTION
Supersedes #175 (closing it) — same goal, but rebuilt from a clean base after review feedback
  there surfaced deeper issues in both my patch and the existing implementation.

  ## Defects fixed in `VolumeHelper`

  1. **Volumes without mount points poisoned matching** — they produced empty/garbage
  `DriveLetter` entries; now skipped at enumeration.
  2. **Stale buffer corruption** — the reused 64K buffers were never cleared, so a shorter string
  left residue from the previous volume (`TrimEnd` on the whole buffer kept embedded NULs and
  stale text), silently corrupting mappings. Buffers are now cleared per iteration and returned
  lengths are honored.
  3. **Search handle leak** — `FindVolumeClose` was never called; now closed in a `finally`, and
  `FindNextVolume` failures other than `ERROR_NO_MORE_FILES` are surfaced instead of silently
  truncating the list.
  4. **`UriFormatException` escaping `throwOnError: false`** — `NormalizePath` used `new
  Uri(path)`, which throws on garbage input; replaced with exception-guarded `Path.GetFullPath`.
  5. **Reverse translation rejected non-`HarddiskVolume` devices** — the regex gate meant entries
  on dynamic disks (`\Device\HarddiskDmVolumes\...`) and similar could be *written* to the
  driver but were silently dropped when reading back. Per the QueryDosDevice docs the target form
  isn't guaranteed (Microsoft's own "Displaying Volume Paths" sample output includes
  `\Device\CdRom0`), so matching is now mapping-driven with a boundary check (`HarddiskVolume1`
  can no longer claim `HarddiskVolume10` paths).
  6. **Mounted folders resolved through the wrong volume** — only the first mount point per
  volume was kept and first-match selection could map a file under a mounted folder via the
  volume root, producing entries the driver never matches. Now one mapping per mount point with
  longest-prefix selection, and the forward direction canonicalizes the input once and slices
  that same string (fixes relative, forward-slash and `..` inputs).

  ## New: DefineDosDevice-backed drives

  `FindFirstVolume` only sees Mount Manager volumes, so VeraCrypt/ImDisk-style drives never
  translated. A drive-letter sweep (`QueryDosDevice("X:")`) now picks them up, with guards:
  network-redirector targets (session-specific `\;X:` segments) are excluded, and one level of
  `\??\` indirection (SUBST) resolves through the Mount Manager mappings.

  ## Behavior changes to be aware of

  - Volume **enumeration** failure now throws `Win32Exception` even with `throwOnError: false`
  (previously it degraded to an empty mapping list, which could silently wipe the blocklist
  during an Add/Remove rewrite). `throwOnError` still governs input-level failures, which return
  `null` as before (docs said "empty string" but the code always returned `null`; docs
  corrected).
  - `ApplicationPaths` now returns entries on non-`HarddiskVolume` devices that were previously
  dropped.
  - No public API changes — all new types are `internal`.

  ## Tests

  `VolumeHelper` had no coverage; this adds 17 tests via an `IVolumeMappingProvider` seam
  (`InternalsVisibleTo("Tests")` in the csproj), including longest-match selection,
  prefix-collision boundaries, canonicalization cases, round-tripping, MULTI_SZ parsing, and one
  live enumeration smoke test. Full suite (24 tests, including the existing driver integration
  tests round-tripping through this code against the real driver) passes; `dotnet build -c
  Release` of the solution is clean on all four TFMs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved device↔path conversion and mapping for more reliable, canonical resolution of complex paths.
  * Updated service whitelist handling to operate in device-path space for robust add/remove semantics.
* **Tests**
  * Added comprehensive tests covering many path/mapping edge cases, mount-point tie-breaks, and a disposable temp-file helper.
  * Marked some hardware-dependent tests as explicit so they don’t run by default.
* **Chores**
  * CI now runs tests on Windows and includes a dedicated test step; test assembly granted access to internals.
* **Other**
  * Added a missing native API entry used during volume enumeration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->